### PR TITLE
fix: add type annotation for Component import in ConnectionWrapper.svelte

### DIFF
--- a/src/presets/classic/components/ConnectionWrapper.svelte
+++ b/src/presets/classic/components/ConnectionWrapper.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Component, onMount } from "svelte";
+  import { type Component, onMount } from "svelte";
   import type { ClassicScheme } from "../types";
   import type { Position } from "../../../types";
   type PositionWatcher = (cb: (value: Position) => void) => () => void;


### PR DESCRIPTION
### Description
Refactor: Explicitly type Component import from svelte

This change explicitly types the Component import from the svelte library. This provides better type safety and can help prevent potential errors related to incorrect component usage.

### Related Issues
This pull request resolves issue https://github.com/retejs/svelte-plugin/issues/14.

### Checklist

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://retejs.org/docs/contribution#contribution) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

### Additional Notes
N/A